### PR TITLE
Lowercase source path for query-builder asset

### DIFF
--- a/QueryBuilderAsset.php
+++ b/QueryBuilderAsset.php
@@ -11,7 +11,7 @@ use yii\web\AssetBundle;
  */
 class QueryBuilderAsset extends AssetBundle {
 
-    public $sourcePath = '@bower/jQuery-QueryBuilder/dist';
+    public $sourcePath = '@bower/jquery-querybuilder/dist';
 
     public $js = [
         'js/query-builder.standalone.min.js',


### PR DESCRIPTION
Because of problems with case-sensitive filesystem this library doesn't work on linux.