### PR TITLE
Add NOT BETWEEN SQL operator

### DIFF
--- a/Translator.php
+++ b/Translator.php
@@ -65,6 +65,7 @@ class Translator extends BaseObject
             'greater' =>          '> ?',
             'greater_or_equal' => '>= ?',
             'between' =>          ['op' => 'BETWEEN ?',   'list' => true, 'sep' => ' AND '],
+            'not_between' =>      ['op' => 'NOT BETWEEN ?',   'list' => true, 'sep' => ' AND '],
             'begins_with' =>      ['op' => 'LIKE ?',     'fn' => function($value){ return "$value%"; } ],
             'not_begins_with' =>  ['op' => 'NOT LIKE ?', 'fn' => function($value){ return "$value%"; } ],
             'contains' =>         ['op' => 'LIKE ?',     'fn' => function($value){ return "%$value%"; } ],
@@ -168,4 +169,4 @@ class Translator extends BaseObject
     {
         return $this->_params;
     }
-} 
+}

--- a/tests/unit/TranslatorTest.php
+++ b/tests/unit/TranslatorTest.php
@@ -47,6 +47,12 @@ class TranslatorTest extends TestCase
             ],
             [
                 ['condition' => "and", 'rules' => [
+                    [ 'field' => 'date', 'type' => 'date', 'operator' => 'not_between', 'value' => ['2015-01-01','2015-01-30']],
+                ]],
+                ['(date NOT BETWEEN :p0 AND :p1)', [':p0'=>'2015-01-01', ':p1'=>'2015-01-30']]
+            ],
+            [
+                ['condition' => "and", 'rules' => [
                     [ 'field' => 'name', 'type' => 'string', 'operator' => 'begins_with', 'value' => 'joe'],
                     [ 'field' => 'name', 'type' => 'string', 'operator' => 'not_begins_with', 'value' => 'bruce'],
                 ]],
@@ -111,4 +117,4 @@ class TranslatorTest extends TestCase
             }
         }
     }
-} 
+}


### PR DESCRIPTION


In case of date related (date data type)  fields such as birth_date, order_date etc

and in case of "NOT BETWEEN" SQL operator which [jQuery query builder](https://querybuilder.js.org/demo.html) support 

I am getting below error

```
Undefined index
not_between
```


Upon investigating, I found that NOT BETWEEN is missing from operators list 

https://github.com/leandrogehlen/yii2-querybuilder/blob/master/Translator.php#L67

When I add

```
'not_between' =>      ['op' => 'NOT BETWEEN ?',   'list' => true, 'sep' => ' AND '],
```

the issue is fixed.


So this PR adds NOT_BETWEEN SQL operator